### PR TITLE
Re-link texture ID to current IMG on resource restart

### DIFF
--- a/eagleLoader/client/asset_loader.lua
+++ b/eagleLoader/client/asset_loader.lua
@@ -51,8 +51,11 @@ end
 local function requestTextureID(assetName, img, path)
     if not textureIDs[assetName] then
         textureIDs[assetName] = engineRequestTXD(assetName)
-        engineImageLinkTXD(img, path, textureIDs[assetName])
     end
+    -- Always re-link to the current IMG: after a resource restart the old IMG
+    -- archive is removed and a new one is created, so the TXD-to-IMG association
+    -- must be re-established even if the TXD slot was already allocated.
+    engineImageLinkTXD(img, path, textureIDs[assetName])
     return textureIDs[assetName]
 end
 


### PR DESCRIPTION
Ensure texture ID is re-linked to the current IMG after resource restart.

Fixes game freezing when reloading maps such as https://github.com/BlueEagle12/MTA-Liberty-City